### PR TITLE
Not calling finish_queries when we have failures for make_getkq_requests.

### DIFF
--- a/lib/dalli/pipelined_getter.rb
+++ b/lib/dalli/pipelined_getter.rb
@@ -29,7 +29,7 @@ module Dalli
 
     def setup_requests(keys)
       groups = groups_for_keys(keys)
-      make_getkq_requests(groups)
+      groups = make_getkq_requests(groups)
 
       # TODO: How does this exit on a NetworkError
       finish_queries(groups.keys)
@@ -44,12 +44,15 @@ module Dalli
     # the opaque value to match requests to responses.
     ##
     def make_getkq_requests(groups)
+      successful_groups = {}
       groups.each do |server, keys_for_server|
         server.request(:pipelined_get, keys_for_server)
+        successful_groups[server] = keys_for_server
       rescue DalliError, NetworkError => e
         Dalli.logger.debug { e.inspect }
         Dalli.logger.debug { "unable to get keys for server #{server.name}" }
       end
+      successful_groups
     end
 
     ##


### PR DESCRIPTION
We have recently seen an issue with multi_get in production when we tuned our memcached's idle_timeout to X hours.

What we have observed is that some processes end up using Dalli::Client's that have connections that were not used for >X hours. Our best theory is that this may happen when concurrency increases in waves as the connection pool may allocate new Dalli:Client that end up unused for a long time when concurrency decreases which is typical in sidekiq worker jobs.

For regular get/put operations, Dalli in general is able to just detect that the connection was closed by the peer and retries with no issues.

However get_multi implementation sometimes appears to hit a bug where it ends up with corrupted state and causes an exception like:
```
[Dalli] No request in progress. This may be a bug in Dalli.
.../lib/dalli/protocol/connection_manager.rb:107:in `confirm_in_progress!'
.../lib/dalli/protocol/base.rb:179:in `verify_pipelined_state'
.../lib/dalli/protocol/base.rb:75:in `pipeline_response_setup'
.../lib/dalli/pipelined_getter.rb:81:in `finish_query_for_server'
.../lib/dalli/pipelined_getter.rb:66:in `block in finish_queries'
.../lib/dalli/pipelined_getter.rb:62:in `each'
.../lib/dalli/pipelined_getter.rb:62:in `finish_queries'
.../lib/dalli/pipelined_getter.rb:35:in `setup_requests'
.../lib/dalli/pipelined_getter.rb:20:in `block in process'
.../lib/dalli/ring.rb:78:in `lock'
.../lib/dalli/pipelined_getter.rb:19:in `process'
.../lib/dalli/client.rb:113:in `block in get_multi'
<internal:kernel>:90:in `tap'
.../lib/dalli/client.rb:112:in `get_multi'
```

This has been tough to reproduce locally, currently only seeing in our production jobs. Based on the exception above, it seems to be failing here when using a connection that is too old:
https://github.com/petergoldstein/dalli/blob/67942b8db6ba8ae9c39e30d9c0c63fb1525586b3/lib/dalli/pipelined_getter.rb#L35

What I believe is currently happening is that make_getkq_requests is hitting a NetworkError and this codepath:
https://github.com/petergoldstein/dalli/blob/67942b8db6ba8ae9c39e30d9c0c63fb1525586b3/lib/dalli/pipelined_getter.rb#L49

That likely triggers the connection to be closed and the connection_manager's state to be reset so that there is no longer a request in progress. However finish_queries is not aware of that and still tries to interact with the connection that was recently closed expecting that there is a request in progress when there are none actually.

The proposed fix in this PR is to pipe the information from make_getkq_requests that there were some servers with failures and we failed to get data for the keys for them so that finish_queries can simply avoid getting those keys.

To test that my changes were safe, I ran locally an integration test that covers get_multi:
```
bundle exec ruby test/integration/test_network.rb
```

