### PR TITLE
Revert "Not calling finish_queries when we have failures for make_getkq_requests."

### DIFF
--- a/lib/dalli/pipelined_getter.rb
+++ b/lib/dalli/pipelined_getter.rb
@@ -29,7 +29,7 @@ module Dalli
 
     def setup_requests(keys)
       groups = groups_for_keys(keys)
-      groups = make_getkq_requests(groups)
+      make_getkq_requests(groups)
 
       # TODO: How does this exit on a NetworkError
       finish_queries(groups.keys)
@@ -44,15 +44,12 @@ module Dalli
     # the opaque value to match requests to responses.
     ##
     def make_getkq_requests(groups)
-      successful_groups = {}
       groups.each do |server, keys_for_server|
         server.request(:pipelined_get, keys_for_server)
-        successful_groups[server] = keys_for_server
       rescue DalliError, NetworkError => e
         Dalli.logger.debug { e.inspect }
         Dalli.logger.debug { "unable to get keys for server #{server.name}" }
       end
-      successful_groups
     end
 
     ##


### PR DESCRIPTION
This reverts commit b80728700183c20d193f7adbe62c78002ee9a0b8.

Not actually needed. https://github.com/petergoldstein/dalli/commit/fa641192072fd3852053f01e65853af95bc0b8d0 seems to fix the issue this was trying to fix already.